### PR TITLE
Additions to sim management

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ Same as above, but for 3D files. Keeps 3D outputs in every 10th output.
 Automatically tar a checkpoint if one hasn't been tarred in >10 outputs. Needs to be done!
 
 ## scan_arrangements.sh
-In order to determine exactly which versions of which thorns are being used in a given Cactus configuration, this script can be placed into the 'arrangements' folder and run with arguments ./ and 0, that is:
-```
-$ ./scan_arrangements.sh ./ 0
-```
-The script will recursively search for repositories in the arrangements folder (following symbolic links of course), and when found print the path to the thorn and the branch of the repository it is using.
+In order to determine exactly which versions of which thorns are being used in a given Cactus configuration, this script can be placed into the 'arrangements' folder and run. It will recursively search for repositories in the arrangements folder (following symbolic links of course), and when found print the path to the thorn and the branch of the repository it is using.
 (The script has a hard-coded depth limit of 4: GetComponents never places the repository links more than one level down, so if 4 levels is not enough it is likely you are not setting up you Cactus conifiguration in a protable way, and you should consider the advice in the next section.)
 
 # Managing Cactus Configurations with GetComponents & Thornlists

--- a/README.md
+++ b/README.md
@@ -22,3 +22,22 @@ Same as above, but for 3D files. Keeps 3D outputs in every 10th output.
 
 ## TODO: tar_checkpoints.sh
 Automatically tar a checkpoint if one hasn't been tarred in >10 outputs. Needs to be done! 
+
+# Managing Cactus Configurations with GetComponents & Thornlists
+
+The high degree of modularity of Cactus codes, along with the necessary hetrogeny inherent to high-performance computing environments, makes setting up working configurations of Cactus a major technical time sink for our work.
+It is therefore vital to make such configurations as sharable and reproducable as possible.
+
+Part of this is achieved by SimFactory. It provides an elaborate mechanism wrapping the Cactus build system to enable compiler settings, environment setup, and simulation setup, queue submission, and run scripts, to be easily shared via .ini, .cfg, .sub, and .run files that entirely capture the setup for Cactus on a given HPC machine, and are easy to share.
+
+However there is still a major missing element: these SimFactory files standardize how Cactus simulations are compiled, set up, and run, but they do not specify *what* is being compiled, set up, and run. Indeed, depending on the languages and libraries needed, a given .ini or .cfg on some machine may not even work with every set of Cactus thorns that could be compiled. Quite simply, there is no singular Cactus code, there are endless combinations of thorns, and it is vital to have a succinct, portable method to specify exactly which of the miriad combinations is being used.
+
+The solution to this issue pre-dates SimFactory, and takes the form of Thornlist files, along with the GetComponents script.
+GetComponents is familiar to any Cactus user as the installation script, but it is much more--it is esentially a parser for the "Component Retrieval Language" (CRL) of the thornlist files. This enables a powerful system for setting up Cactus configurations with thorns from around the internet.
+
+Thornlists specify both the repositories where code can be found, and the structure of Cactus's arrangements folder, where the thorns Cactus will use are collected. Using GetComponents, the checking out of code from repositories as well as the setup of the arrangements folder can be automated. If changes are made to the thornlist, one can simply run GetComponents from one level above the Cactus folder with the modified thornlist as its only argument, and GetComponents will make the necessary updates.
+
+In this way, the thornlists act a simple database (much like the .ini, .cfg, .sub, and .run files), which uniquely determine the set of code repositories that are checked out, down to the branch version, and the arrangments structure. As a bonus, thornlists are also used by the build system to specify which thorns are to be built into a given Cactus configuration.
+
+In ```example_azrelativity_thornlist.th``` I show what to _append_ to a standard Einstein Toolkit thornlist in order to check out and install the thorns in our GitHub organization. For more about the CRL language of thornlists that is parsed by GetComponents, see:
+https://github.com/gridaphobe/CRL/wiki/Component-Retrieval-Language

--- a/README.md
+++ b/README.md
@@ -43,5 +43,11 @@ Thornlists specify both the repositories where code can be found, and the struct
 
 In this way, the thornlists act a simple database (much like the .ini, .cfg, .sub, and .run files), which uniquely determine the set of code repositories that are checked out, down to the branch version, and the arrangments structure. As a bonus, thornlists are also used by the build system to specify which thorns are to be built into a given Cactus configuration.
 
-In ```example_azrelativity_thornlist.th``` I show what to _append_ to a standard Einstein Toolkit thornlist in order to check out and install the thorns in our GitHub organization. For more about the CRL language of thornlists that is parsed by GetComponents, see:
+In ```example_azrelativity_thornlist.th``` I show what to _append_ to a standard Einstein Toolkit thornlist in order to check out and install the thorns in our GitHub organization. If appending ```example_azrelativity_thornlist.th``` to ```einsteintoolkit.th``` (for example) and removing andy redundant thonrs, results in ```updated_thornlist.th```, then the associated configuration would either be installed fresh or updated by going to the directory above Cactus and running:
+```
+$ ./GetComponents updated_thornlist.th
+```
+And following the prompts.
+
+For more about the CRL language of thornlists that is parsed by GetComponents, see:
 https://github.com/gridaphobe/CRL/wiki/Component-Retrieval-Language

--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ When a simulation is finished and analysis is done, you want to keep a minimum v
 Same as above, but for 3D files. Keeps 3D outputs in every 10th output.
 
 ## TODO: tar_checkpoints.sh
-Automatically tar a checkpoint if one hasn't been tarred in >10 outputs. Needs to be done! 
+Automatically tar a checkpoint if one hasn't been tarred in >10 outputs. Needs to be done!
+
+## scan_arrangements.sh
+In order to determine exactly which versions of which thorns are being used in a given Cactus configuration, this script can be placed into the 'arrangements' folder and run with arguments ./ and 0, that is:
+```
+$ ./scan_arrangements.sh ./ 0
+```
+The script will recursively search for repositories in the arrangements folder (following symbolic links of course), and when found print the path to the thorn and the branch of the repository it is using.
+(The script has a hard-coded depth limit of 4: GetComponents never places the repository links more than one level down, so if 4 levels is not enough it is likely you are not setting up you Cactus conifiguration in a protable way, and you should consider the advice in the next section.)
 
 # Managing Cactus Configurations with GetComponents & Thornlists
 

--- a/example_azrelativity_thornlist.th
+++ b/example_azrelativity_thornlist.th
@@ -21,8 +21,7 @@ AZRelativity/TwoPuncturesPowerLaw
 
 # Private thorns - These ones need to be checked out and symlinked into arrangments manually
 # However, by including them in this thornlist symfactory can be used to build them.
-!TARGET   = $ARR
-!TYPE     = ignore
-!CHECKOUT =
-MPn/MPn
-MPn/ID_MPn
+#!TARGET   = $ARR
+#!TYPE     = ignore
+#!CHECKOUT =
+#(List private thorns here, with the paths they have in the arrangements folder)

--- a/example_azrelativity_thornlist.th
+++ b/example_azrelativity_thornlist.th
@@ -1,0 +1,28 @@
+# The below lines can be appended to an existing Einstein Toolkit thornlist to add arizona-relativity thorns to the Cactus install
+# created by GetComponents. See the instructions in the README for the right way to use thornlists to manage Cactus installs and
+# configurations.
+
+# Thorns from the arizona relativity repo - as long as no password needs to be typed, these can be checked out just like public repos!
+!TARGET   = $ARR # This variable is set above to correspond to the Cactus/arrangments directory, where the thorns should be symlinked
+!TYPE     = git
+!URL      = git@github.com:arizona-relativity/$2 # The variable $2 is the string after the first / in !CHECKOUT
+#!REPO_BRANCH = main # It seems like we can just leave this blank when checking out main
+!REPO_PATH = ../$2 # GetComponents needs a folder to copy the contents of: to copy the current folder we go back a level and then target $2
+# Feel free to comment out any thorns you don't want below:
+!CHECKOUT =
+AZRelativity/CocalBHT
+AZRelativity/IllinoisGRMHD
+AZRelativity/LeanBSSNMoL
+AZRelativity/Christoffel
+AZRelativity/QuasiLocalMeasuresMHD
+AZRelativity/DiskDiagnostics
+AZRelativity/TwoPuncturesPowerLaw
+# ^ Note that the arrangment name, 'AZRelativity', doesn't have to have anything to do with the repository name
+
+# Private thorns - These ones need to be checked out and symlinked into arrangments manually
+# However, by including them in this thornlist symfactory can be used to build them.
+!TARGET   = $ARR
+!TYPE     = ignore
+!CHECKOUT =
+MPn/MPn
+MPn/ID_MPn

--- a/scan_arrangements.sh
+++ b/scan_arrangements.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+recursive_repo_search()
+{
+        for DIR in $(find -L $1 -mindepth 1 -maxdepth 1 -type d) ; do
+                #echo $DIR
+                cd $DIR
+                if git rev-parse --git-dir > /dev/null 2>&1; then
+                        # This is a valid git repository
+                        pwd
+                        git branch
+                        cd - > /dev/null
+                        #echo "$DIR is a git repo"
+                else
+                        # this is not a git repository
+                        cd - > /dev/null
+                        if (( $2 < 4 )); then
+                                #echo "Recursing to level $(( $2 + 1 ))..."
+                                recursive_repo_search $DIR $(( $2 + 1 ))
+                        else
+                                echo "Hard-coded depth limit reached! What is up with your arrangements folder?"
+                        fi
+                fi
+        done
+}
+
+recursive_repo_search ./ 1


### PR DESCRIPTION
As long promised, I have added instructions explaining how to use thornlists and GetComponents to make Cactus installs more portable and reproducible (sorry they are somewhat long-winded). I have also added my scan_arrangements.sh to the repository, which is useful for determining what version of each thorn is actually being used.